### PR TITLE
HOTFIX: Turn hours back by one to fix timed messages

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -127,7 +127,7 @@ async def checkReminders():
 
 checkReminders.start()
 scheduler = AsyncIOScheduler()
-scheduler.add_job(scooby.whatsTheMove, CronTrigger(hour = "19", minute = "0", second = "0", timezone="EST"))
-scheduler.add_job(scooby.praiseFireGator, CronTrigger(day_of_week="thu", hour = "0", minute = "0", second = "0", timezone="EST"))
+scheduler.add_job(scooby.whatsTheMove, CronTrigger(hour = "18", minute = "0", second = "0", timezone="EST"))
+scheduler.add_job(scooby.praiseFireGator, CronTrigger(day_of_week="wed", hour = "23", minute = "0", second = "0", timezone="EST"))
 scheduler.start()
 bot.run(config["token"])


### PR DESCRIPTION
Daylight savings time works weirdly with `CronTrigger` and does not accept `DST` as a timezone, so I am manually moving the hours back by one to make dad send messages at the right time.